### PR TITLE
Task: Prevent usage of count(NULL)

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -89,6 +89,11 @@ class AddressController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
                 $isSearch = TRUE;
         }
 
+        /**
+         * array Stores UIDs of records to be assigned to the view.
+         */
+        $addressRecords = [];
+
         if ($this->settings['addressStoragePages'] && ($this->settings['addressStoragePages'] != '')) {
             $addressRecords = $this->addressRepository->findInPageIds($this->settings['addressStoragePages'], $this->settings['orderBy'], $this->settings['orderDirection']);
         }

--- a/Configuration/TCA/tx_hwtaddress_domain_model_address.php
+++ b/Configuration/TCA/tx_hwtaddress_domain_model_address.php
@@ -52,7 +52,7 @@ $extTca = array(
             company_title,company_subtitle,company_short,company_bodytext,company_images,
             phone,mobile,fax,email,www,street,building,zip,city,region,country,longitude,latitude'
     ),
-    'feInterface' => $TCA['tx_hwtaddress_domain_model_address']['feInterface'],
+    'feInterface' => $GLOBALS['TCA']['tx_hwtaddress_domain_model_address']['feInterface'],
     'columns' => array(
         'sys_language_uid' => [
             'exclude' => true,

--- a/Configuration/TCA/tx_hwtaddress_domain_model_link.php
+++ b/Configuration/TCA/tx_hwtaddress_domain_model_link.php
@@ -45,7 +45,7 @@ $extTca = array(
     'interface' => array(
         'showRecordFieldList' => 'sorting,hidden,starttime,endtime,header,type,parameter,linktext'
     ),
-    'feInterface' => $TCA['tx_hwtaddress_domain_model_link']['feInterface'],
+    'feInterface' => $GLOBALS['TCA']['tx_hwtaddress_domain_model_link']['feInterface'],
     'columns' => array(
         'pid' => array(
             'label' => 'pid',


### PR DESCRIPTION
Hi, 

there is a warning about usage of count on NULL. 
I removed that by assigning an empty array just before the if clauses. 

Additionally I found some missing refactoring in in usage of $TCA and not $GLOBALS['TCA']