### PR TITLE
FIX: exception in page module when pi_flexform hasn't been written yet

### DIFF
--- a/Classes/Hooks/CmsLayout.php
+++ b/Classes/Hooks/CmsLayout.php
@@ -91,11 +91,12 @@ class CmsLayout {
             $this->flexformData = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 
-            $actions = $this->getFieldFromFlexform('switchableControllerActions');
-            $actionsArray = explode(';', $actions);
-            foreach ( $actionsArray as $action ) {
-                $action = strtolower(str_replace('->', '_', $action));
-                $result .= $this->getPluginLL(self::LLPATH . 'flexform_setting.mode.' . $action) . ' ';
+            if ($actions = $this->getFieldFromFlexform('switchableControllerActions')) {
+                $actionsArray = explode(';', $actions);
+                foreach ( $actionsArray as $action ) {
+                    $action = strtolower(str_replace('->', '_', $action));
+                    $result .= $this->getPluginLL(self::LLPATH . 'flexform_setting.mode.' . $action) . ' ';
+                }
             }
 
 


### PR DESCRIPTION
There's an exception in page module when the plugin has `pi_flexform` set to NULL. Don't know how my BE users were able to get there but they did ;-)